### PR TITLE
Ensure the log directory exists

### DIFF
--- a/App/Log.cs
+++ b/App/Log.cs
@@ -15,7 +15,18 @@ public static class Log
     string msg = $"{DateTime.Now} {nameof(BrowseRouter)}: {message}";
     Console.WriteLine(msg);
     eventLog_.WriteEntry(msg);
+
+    EnsureLogDirExists();
     TryWrite(msg);
+  }
+
+  private static void EnsureLogDirExists()
+  {
+    var parent = Path.GetDirectoryName(Preference.File);
+    if (parent is not null)
+    {
+      Directory.CreateDirectory(parent);
+    }
   }
 
   private static void TryWrite(string message)

--- a/App/LogPreference.cs
+++ b/App/LogPreference.cs
@@ -2,7 +2,8 @@
 
 public class LogPreference
 {
-  public static string DefaultLogFile => $"{Env.LocalAppData}/BrowseRouter/{DateTime.Today:yyyy-MM-dd}.log";
+  public static string DefaultLogRoot => $"{Env.LocalAppData}/BrowseRouter/";
+  public static string DefaultLogFile => $"{DefaultLogRoot}{DateTime.Today:yyyy-MM-dd}.log";
 
   public bool IsEnabled { get; set; }
   public string File { get; set; } = DefaultLogFile;

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Config is a poor man's INI file:
 [log]
 # Defaults to false
 enabled = true
-# Defaults to C:\Users\<user>\AppData\Local\BrowseRouter
+# Defaults to C:\Users\<user>\AppData\Local\BrowseRouter\yyyy-MM-dd.log
 #file = "C:\Users\<user>\Desktop\BrowseRouter.log"
 
 ; Default browser is first in list


### PR DESCRIPTION
Fixes `DirectoryNotFoundException` which happens e.g. on a new install when the log dir does not exist.