### PR TITLE
Fix lingering tray icon on Windows 10

### DIFF
--- a/BrowseRouter/NotifyService.cs
+++ b/BrowseRouter/NotifyService.cs
@@ -45,7 +45,7 @@ public class NotifyService : INotifyService
     // If we exit too early, the title has a GUID rather than the app name, and no icon.
     await Task.Delay(500);
 
-    bool isWindows11 = Environment.OSVersion.Version.Build > 2200;
+    bool isWindows11 = Environment.OSVersion.Version.Build > 22000;
 
     if (isWindows11)
       return;

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.12.1</Version>
+    <Version>0.12.2</Version>
     <Product>BrowseRouter</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>
     <!-- Reduces flagging as malware -->


### PR DESCRIPTION
Typo in Windows version check led to the app behaving in a way that only works on Windows 11, namely not explicitly deleting the tray icon.