### PR TITLE
Remove .ToLower() on URLs to preserve case sensitive parameters

### DIFF
--- a/BrowseRouter/Program.cs
+++ b/BrowseRouter/Program.cs
@@ -15,7 +15,7 @@ public static class Program
     // Process each URL in the arguments list.
     foreach (string arg in args)
     {
-      await RunAsync(arg.Trim().ToLower());
+      await RunAsync(arg.Trim());
     }
   }
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.12.2</Version>
+    <Version>0.12.3</Version>
     <Product>BrowseRouter</Product>
     <Copyright>EnduraByte LLC 2024</Copyright>
     <!-- Reduces flagging as malware -->


### PR DESCRIPTION
Fixes #45 