### PR TITLE
Treated project Warnings, relevant suggestions and non-obvious "var" uses

### DIFF
--- a/BrowseRouter/App.cs
+++ b/BrowseRouter/App.cs
@@ -4,30 +4,30 @@ namespace BrowseRouter;
 
 public static class App
 {
-  private static string exePath;
+  private static string? _exePath;
 
   public static string ExePath
   {
     get
     {
-      if (!string.IsNullOrEmpty(exePath))
+      if (!string.IsNullOrEmpty(_exePath))
       {
-        return exePath;
+        return _exePath;
       }
 
       var assembly = Assembly.GetExecutingAssembly();
       // .NET Core returns BrowserSettings.dll but we need BrowserSettings.exe
-      exePath = Assembly.GetExecutingAssembly().Location
+      _exePath = assembly.Location
           .Replace(".dll", ".exe");
 
-      if (!string.IsNullOrEmpty(exePath))
+      if (!string.IsNullOrEmpty(_exePath))
       {
-        return exePath;
+        return _exePath;
       }
 
       var dir = AppDomain.CurrentDomain.BaseDirectory;
-      exePath = Path.Combine(dir, AppDomain.CurrentDomain.FriendlyName + ".exe");
-      return exePath;
+      _exePath = Path.Combine(dir, AppDomain.CurrentDomain.FriendlyName + ".exe");
+      return _exePath;
     }
   }
 }

--- a/BrowseRouter/App.cs
+++ b/BrowseRouter/App.cs
@@ -25,7 +25,7 @@ public static class App
         return _exePath;
       }
 
-      var dir = AppDomain.CurrentDomain.BaseDirectory;
+      string dir = AppDomain.CurrentDomain.BaseDirectory;
       _exePath = Path.Combine(dir, AppDomain.CurrentDomain.FriendlyName + ".exe");
       return _exePath;
     }

--- a/BrowseRouter/Browser.cs
+++ b/BrowseRouter/Browser.cs
@@ -2,8 +2,8 @@
 
 public class Browser
 {
-  public string Name { get; set; }
-  public string Location { get; set; }
+  public required string Name { get; set; }
+  public required string Location { get; set; }
 
   public override string ToString() => $"\"{Name}\" (\"{Location}\")";
 }

--- a/BrowseRouter/BrowserService.cs
+++ b/BrowseRouter/BrowserService.cs
@@ -51,7 +51,7 @@ public class BrowserService(IConfigService config, INotifyService notifier)
   private static string GetAppName(string path)
   {
     // Get just the app name from the exe at path
-    var name = Path.GetFileNameWithoutExtension(path);
+    string name = Path.GetFileNameWithoutExtension(path);
     // make first letter uppercase
     name = name[0].ToString().ToUpper() + name[1..];
     return name;

--- a/BrowseRouter/ConfigService.cs
+++ b/BrowseRouter/ConfigService.cs
@@ -15,7 +15,7 @@ public class ConfigService : IConfigService
   public ConfigService()
   {
     // Fix for self-contained publishing
-    this.ConfigPath = Path.Combine(Path.GetDirectoryName(App.ExePath)!, "config.ini");
+    ConfigPath = Path.Combine(Path.GetDirectoryName(App.ExePath)!, "config.ini");
   }
 
   public bool GetIsLogEnabled() => File.Exists(ConfigPath) 
@@ -78,7 +78,7 @@ public class ConfigService : IConfigService
       .Select(kvp => new Browser { Name = kvp.Key, Location = kvp.Value })
       .ToDictionary(b => b.Name);
 
-    if (!browsers.Any())
+    if (browsers.Count == 0)
     {
       // There weren't any configured browsers
       return new List<UrlPreference>();
@@ -100,7 +100,7 @@ public class ConfigService : IConfigService
   {
     return File.ReadAllLines(ConfigPath)
       .Select(l => l.Trim())
-      .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith(";") && !l.StartsWith("#"));
+      .Where(l => !string.IsNullOrWhiteSpace(l) && !l.StartsWith(';') && !l.StartsWith('#'));
   }
 
   private IEnumerable<string> GetConfig(IEnumerable<string> configLines, string configName)
@@ -118,7 +118,7 @@ public class ConfigService : IConfigService
   /// </summary>
   private KeyValuePair<string, string> SplitConfig(string configLine)
   {
-    var parts = configLine.Split(new[] { '=' }, 2);
+    var parts = configLine.Split('=', 2);
     return new KeyValuePair<string, string>(parts[0].Trim(), parts[1].Trim());
   }
 }

--- a/BrowseRouter/ConfigService.cs
+++ b/BrowseRouter/ConfigService.cs
@@ -31,7 +31,7 @@ public class ConfigService : IConfigService
 
   private NotifyPreference GetNotifyPreferenceCore()
   {
-    var notifyConfig = GetConfig(ReadFile(), "notify")
+    Dictionary<string, string> notifyConfig = GetConfig(ReadFile(), "notify")
       .Select(SplitConfig)
       .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
@@ -53,7 +53,7 @@ public class ConfigService : IConfigService
 
   private LogPreference GetLogPreferenceCore()
   {
-    var logConfig = GetConfig(ReadFile(), "log")
+    Dictionary<string, string> logConfig = GetConfig(ReadFile(), "log")
       .Select(SplitConfig)
       .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
@@ -73,7 +73,7 @@ public class ConfigService : IConfigService
     IEnumerable<string> configLines = ReadFile();
 
     // Read the browsers section into a dictionary.
-    var browsers = GetConfig(configLines, "browsers")
+    Dictionary<string, Browser> browsers = GetConfig(configLines, "browsers")
       .Select(SplitConfig)
       .Select(kvp => new Browser { Name = kvp.Key, Location = kvp.Value })
       .ToDictionary(b => b.Name);
@@ -85,7 +85,7 @@ public class ConfigService : IConfigService
     }
 
     // Read the url preferences
-    var urls = GetConfig(configLines, configType)
+    IEnumerable<UrlPreference> urls = GetConfig(configLines, configType)
       .Select(SplitConfig)
       .Select(kvp => new UrlPreference { UrlPattern = kvp.Key, Browser = browsers[kvp.Value] })
       .Where(up => up.Browser != null);
@@ -118,7 +118,7 @@ public class ConfigService : IConfigService
   /// </summary>
   private KeyValuePair<string, string> SplitConfig(string configLine)
   {
-    var parts = configLine.Split('=', 2);
+    string[] parts = configLine.Split('=', 2);
     return new KeyValuePair<string, string>(parts[0].Trim(), parts[1].Trim());
   }
 }

--- a/BrowseRouter/DefaultBrowserService.cs
+++ b/BrowseRouter/DefaultBrowserService.cs
@@ -40,7 +40,7 @@ public class DefaultBrowserService(INotifyService notifier)
 
   public async Task RegisterOrUnregisterAsync()
   {
-    var status = GetRegisterStatus();
+    RegisterStatus status = GetRegisterStatus();
 
     if (status == RegisterStatus.Unregistered)
     {

--- a/BrowseRouter/DefaultBrowserService.cs
+++ b/BrowseRouter/DefaultBrowserService.cs
@@ -5,15 +5,15 @@ namespace BrowseRouter;
 
 public class DefaultBrowserService(INotifyService notifier)
 {
-  private const string AppName = "BrowseRouter";
-  private const string AppID = "BrowseRouter";
-  private const string AppDescription = "Opens a different brower based on the URL";
+  private const string _appName = "BrowseRouter";
+  private const string _appID = "BrowseRouter";
+  private const string _appDescription = "Opens a different brower based on the URL";
   private string AppIcon => App.ExePath + ",0";
   private string AppOpenUrlCommand => App.ExePath + " %1";
 
-  private string AppKey => $"SOFTWARE\\{AppID}";
-  private string UrlKey => $"SOFTWARE\\Classes\\{AppID}URL";
-  private string CapabilityKey => $"SOFTWARE\\{AppID}\\Capabilities";
+  private string AppKey => $"SOFTWARE\\{_appID}";
+  private string UrlKey => $"SOFTWARE\\Classes\\{_appID}URL";
+  private string CapabilityKey => $"SOFTWARE\\{_appID}\\Capabilities";
 
   private readonly RegistryKey? _registerKey = Registry.CurrentUser.OpenSubKey("SOFTWARE\\RegisteredApplications", true);
   private RegistryKey? AppRegKey => Registry.CurrentUser.OpenSubKey(AppKey);
@@ -58,14 +58,14 @@ public class DefaultBrowserService(INotifyService notifier)
     {
       Unregister(); // Unregister the old path
       Register(); // Register with the new path
-      await notifier.NotifyAsync("Updated location.", $"{AppName} has been re-registered with a new path.");
+      await notifier.NotifyAsync("Updated location.", $"{_appName} has been re-registered with a new path.");
     }
   }
 
   public async Task RegisterAsync()
   {
     Register();
-    await notifier.NotifyAsync("Registered as a browser.", $"Please set {AppName} as the default browser in Settings.");
+    await notifier.NotifyAsync("Registered as a browser.", $"Please set {_appName} as the default browser in Settings.");
   }
 
   private void Register()
@@ -75,17 +75,17 @@ public class DefaultBrowserService(INotifyService notifier)
 
     RegisterCapabilities(appReg);
 
-    _registerKey?.SetValue(AppID, CapabilityKey);
+    _registerKey?.SetValue(_appID, CapabilityKey);
 
     HandleUrls();
 
     OpenSettings();
-    Log.Write($"Done. Please set {AppName} as the default browser in Settings.");
+    Log.Write($"Done. Please set {_appName} as the default browser in Settings.");
   }
 
   private static void OpenSettings() => Process.Start(new ProcessStartInfo
   {
-    FileName = $"ms-settings:defaultapps?registeredAppUser={AppName}",
+    FileName = $"ms-settings:defaultapps?registeredAppUser={_appName}",
     UseShellExecute = true
   });
 
@@ -93,15 +93,15 @@ public class DefaultBrowserService(INotifyService notifier)
   {
     // Register capabilities.
     RegistryKey? capabilityReg = appReg.CreateSubKey("Capabilities");
-    capabilityReg.SetValue("ApplicationName", AppName);
+    capabilityReg.SetValue("ApplicationName", _appName);
     capabilityReg.SetValue("ApplicationIcon", AppIcon);
-    capabilityReg.SetValue("ApplicationDescription", AppDescription);
+    capabilityReg.SetValue("ApplicationDescription", _appDescription);
 
     // Set up protocols we want to handle.
     RegistryKey? urlAssocReg = capabilityReg.CreateSubKey("URLAssociations");
-    urlAssocReg.SetValue("http", AppID + "URL");
-    urlAssocReg.SetValue("https", AppID + "URL");
-    urlAssocReg.SetValue("ftp", AppID + "URL");
+    urlAssocReg.SetValue("http", _appID + "URL");
+    urlAssocReg.SetValue("https", _appID + "URL");
+    urlAssocReg.SetValue("ftp", _appID + "URL");
   }
 
   /// <summary>
@@ -110,22 +110,22 @@ public class DefaultBrowserService(INotifyService notifier)
   private void HandleUrls()
   {
     RegistryKey? handlerReg = Registry.CurrentUser.CreateSubKey(UrlKey);
-    handlerReg.SetValue("", AppName);
-    handlerReg.SetValue("FriendlyTypeName", AppName);
+    handlerReg.SetValue("", _appName);
+    handlerReg.SetValue("FriendlyTypeName", _appName);
     handlerReg.CreateSubKey("shell\\open\\command").SetValue("", AppOpenUrlCommand);
   }
 
   public async Task UnregisterAsync()
   {
     Unregister();
-    await notifier.NotifyAsync("Unregistered as a browser.", $"{AppName} is no longer registered as a web browser.");
+    await notifier.NotifyAsync("Unregistered as a browser.", $"{_appName} is no longer registered as a web browser.");
   }
 
   private void Unregister()
   {
     Log.Write("Unregistering...");
     Try(() => Registry.CurrentUser.DeleteSubKeyTree(AppKey, false));
-    Try(() => _registerKey?.DeleteValue(AppID));
+    Try(() => _registerKey?.DeleteValue(_appID));
     Try(() => Registry.CurrentUser.DeleteSubKeyTree(UrlKey));
     Log.Write("Done");
   }

--- a/BrowseRouter/Log.cs
+++ b/BrowseRouter/Log.cs
@@ -36,7 +36,7 @@ public static class Log
         writer.WriteLine(message);
         return;
       }
-      catch (Exception e)
+      catch (Exception)
       {
       }
     }

--- a/BrowseRouter/Log.cs
+++ b/BrowseRouter/Log.cs
@@ -19,7 +19,7 @@ public static class Log
 
   private static void EnsureLogDirExists()
   {
-    var parent = Path.GetDirectoryName(Preference.File);
+    string? parent = Path.GetDirectoryName(Preference.File);
     if (parent is not null)
     {
       Directory.CreateDirectory(parent);

--- a/BrowseRouter/Program.cs
+++ b/BrowseRouter/Program.cs
@@ -64,12 +64,12 @@ public static class Program
   private static async Task LaunchUrlAsyc(string url)
   {
     // Get the window title for whichever application is opening the URL.
-    var windowTitle = User32.GetActiveWindowTitle();
+    string windowTitle = User32.GetActiveWindowTitle();
 
     var configService = new ConfigService();
     Log.Preference = configService.GetLogPreference();
 
-    var notifyPref = configService.GetNotifyPreference();
+    NotifyPreference notifyPref = configService.GetNotifyPreference();
     INotifyService notifier = notifyPref.IsEnabled switch
     {
       true => new NotifyService(),

--- a/BrowseRouter/UrlPreference.cs
+++ b/BrowseRouter/UrlPreference.cs
@@ -2,8 +2,8 @@
 
 public class UrlPreference
 {
-  public string UrlPattern { get; set; }
-  public Browser Browser { get; set; }
+  public required string UrlPattern { get; set; }
+  public required Browser Browser { get; set; }
 
   public override string ToString() => $"\"{UrlPattern}\" => {Browser}";
 }

--- a/BrowseRouter/UrlPreferenceExtensions.cs
+++ b/BrowseRouter/UrlPreferenceExtensions.cs
@@ -35,7 +35,7 @@ public static class UrlPreferenceExtensions
       string pattern = urlPattern.Substring(1, urlPattern.Length - 2);
 
       // Escape the input for regex; the only special character we support is a *
-      var regex = Regex.Escape(pattern);
+      string regex = Regex.Escape(pattern);
 
       // Unescape * as a wildcard.
       pattern = $"^{regex.Replace("\\*", ".*")}$";
@@ -48,7 +48,7 @@ public static class UrlPreferenceExtensions
       string domain = uri.Authority;
 
       // Escape the input for regex; the only special character we support is a *
-      var regex = Regex.Escape(urlPattern);
+      string regex = Regex.Escape(urlPattern);
 
       // Unescape * as a wildcard.
       string pattern = $"^{regex.Replace("\\*", ".*")}$";
@@ -83,7 +83,7 @@ public static class UrlPreferenceExtensions
     {
       // We're only checking the window title.
       // Escape the input for regex; the only special character we support is a *
-      var regex = Regex.Escape(urlPattern);
+      string regex = Regex.Escape(urlPattern);
 
       // Unescape * as a wildcard.
       string pattern = $"^{regex.Replace("\\*", ".*")}$";

--- a/BrowseRouter/UrlPreferenceExtensions.cs
+++ b/BrowseRouter/UrlPreferenceExtensions.cs
@@ -19,7 +19,7 @@ public static class UrlPreferenceExtensions
   {
     string urlPattern = pref.UrlPattern;
 
-    if (urlPattern.StartsWith("/") && urlPattern.EndsWith("/"))
+    if (urlPattern.StartsWith('/') && urlPattern.EndsWith('/'))
     {
       // The domain from the INI file is a regex
       string domain = uri.Authority + uri.AbsolutePath;
@@ -28,7 +28,7 @@ public static class UrlPreferenceExtensions
       return (domain, pattern);
     }
 
-    if (urlPattern.StartsWith("?") && urlPattern.EndsWith("?"))
+    if (urlPattern.StartsWith('?') && urlPattern.EndsWith('?'))
     {
       // The domain from the INI file is a query filter
       string domain = uri.Authority + uri.PathAndQuery;
@@ -72,7 +72,7 @@ public static class UrlPreferenceExtensions
   {
     string urlPattern = pref.UrlPattern;
 
-    if (urlPattern.StartsWith("/") && urlPattern.EndsWith("/"))
+    if (urlPattern.StartsWith('/') && urlPattern.EndsWith('/'))
     {
       // The window title from the INI file is a regex
       string pattern = urlPattern.Substring(1, urlPattern.Length - 2);


### PR DESCRIPTION
Proposition for [this issue](https://github.com/nref/BrowseRouter/issues/56)

This treats:
- the project warnings*
- some relevant suggestions*
- "var" uses in lines where the underlying type is not obvious (as we discuted [here](https://github.com/nref/BrowseRouter/pull/48#issuecomment-2491707799) )

\* in Visual Studio at least (some other IDE or with custom preferences may raises other warnings/suggestions i suppose)