### PR TITLE
Fix for the 10 sec delay when opening links with notif enabled on Win10

### DIFF
--- a/BrowseRouter/BrowserService.cs
+++ b/BrowseRouter/BrowserService.cs
@@ -38,9 +38,9 @@ public class BrowserService(IConfigService config, INotifyService notifier)
       Log.Write($"Launching {path} with args \"{args} {uri.OriginalString}\"");
 
       string name = GetAppName(path);
-      await notifier.NotifyAsync($"Opening {name}", $"URL: {url}");
-
       Process.Start(path, $"{args} \"{uri.OriginalString}\"");
+
+      await notifier.NotifyAsync($"Opened {name}", $"URL: {url}");
     }
     catch (Exception e)
     {


### PR DESCRIPTION
Fix for [issue 58](https://github.com/nref/BrowseRouter/issues/58#issue-2702688961)