### PR TITLE
Silent notifications + parameter for it in config

### DIFF
--- a/BrowseRouter/ConfigService.cs
+++ b/BrowseRouter/ConfigService.cs
@@ -40,11 +40,16 @@ public class ConfigService : IConfigService
 
     return new NotifyPreference
     {
-      IsEnabled = notifyConfig.TryGetValue("enabled", out string? enabled) switch
-      {
-        false => true,
-        true => bool.TryParse(enabled, out bool isEnabled) && isEnabled,
-      }
+      IsEnabled = notifyConfig.TryGetValue("enabled", out string? enabled) ?
+                    bool.TryParse(enabled, out bool isEnabled) ?
+                      isEnabled :
+                      NotifyPreference.IsEnabledDefaultValue :
+                    NotifyPreference.IsEnabledDefaultValue,
+      IsSilent = notifyConfig.TryGetValue("silent", out string? silent) ?
+                    bool.TryParse(silent, out bool isSilent) ?
+                      isSilent :
+                      NotifyPreference.IsSilentDefaultValue :
+                    NotifyPreference.IsSilentDefaultValue
     };
   }
 

--- a/BrowseRouter/Interop/Win32/Shell32.cs
+++ b/BrowseRouter/Interop/Win32/Shell32.cs
@@ -13,8 +13,9 @@ public static class Shell32
   public const uint NIF_STATE = 0x00000008;
   public const uint NIF_INFO = 0x00000010;
   public const uint NIIF_INFO = 0x00000001;
-  public const int NIIF_USER = 0x00000004;
-  public const int NIIF_LARGE_ICON = 0x00000020;
+  public const uint NIIF_USER = 0x00000004;
+  public const uint NIIF_NOSOUND = 0x00000010;
+  public const uint NIIF_LARGE_ICON = 0x00000020;
   public const int NIS_HIDDEN = 0x00000001;
   public const uint NOTIFYICON_VERSION_4 = 4;
 

--- a/BrowseRouter/NotifyPreference.cs
+++ b/BrowseRouter/NotifyPreference.cs
@@ -2,5 +2,8 @@
 
 public class NotifyPreference
 {
+  public const bool IsEnabledDefaultValue = true;
+  public const bool IsSilentDefaultValue = true;
   public bool IsEnabled { get; set; }
+  public bool IsSilent { get; set; }
 }

--- a/BrowseRouter/Program.cs
+++ b/BrowseRouter/Program.cs
@@ -8,7 +8,7 @@ public static class Program
   {
     if (args.Length == 0)
     {
-      await new DefaultBrowserService(new NotifyService()).RegisterOrUnregisterAsync();
+      await new DefaultBrowserService(new NotifyService(false)).RegisterOrUnregisterAsync();
       return;
     }
 
@@ -48,13 +48,13 @@ public static class Program
 
     if (string.Equals(arg, "r") || string.Equals(arg, "register"))
     {
-      await new DefaultBrowserService(new NotifyService()).RegisterAsync();
+      await new DefaultBrowserService(new NotifyService(false)).RegisterAsync();
       return true;
     }
 
     if (string.Equals(arg, "u") || string.Equals(arg, "unregister"))
     {
-      await new DefaultBrowserService(new NotifyService()).UnregisterAsync();
+      await new DefaultBrowserService(new NotifyService(false)).UnregisterAsync();
       return true;
     }
 
@@ -72,7 +72,7 @@ public static class Program
     NotifyPreference notifyPref = configService.GetNotifyPreference();
     INotifyService notifier = notifyPref.IsEnabled switch
     {
-      true => new NotifyService(),
+      true => new NotifyService(notifyPref.IsSilent),
       false => new EmptyNotifyService()
     };
 


### PR DESCRIPTION
proposition for [this enhancement](https://github.com/nref/BrowseRouter/issues/69)
I feel like this could be cleaner, but it works! If you want me to rework some part of the code don't hesitate!

This adds the bool parameter `silent` in the config file (which default to `true` if not precised).
For registering/unregistering action the notif sound is still always played (as I believe those are more important notifications compared to the "opening link" ones)