### PR TITLE
Fix issue 89

### DIFF
--- a/BrowseRouter/Services/DefaultBrowserService.cs
+++ b/BrowseRouter/Services/DefaultBrowserService.cs
@@ -11,7 +11,7 @@ public class DefaultBrowserService(INotifyService notifier)
   private const string _appID = "BrowseRouter";
   private const string _appDescription = "Opens a different brower based on the URL";
   private string AppIcon => App.ExePath + ",0";
-  private string AppOpenUrlCommand => $"{App.ExePath.Quote()} %1";
+  private string AppOpenUrlCommand => $"{App.ExePath.Quote()} {"%1".Quote()}";
 
   private string AppKey => $"SOFTWARE\\{_appID}";
   private string UrlKey => $"SOFTWARE\\Classes\\{_appID}URL";

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
-    <Version>0.16.0</Version>
+    <Version>0.17.0</Version>
     <Product>BrowseRouter</Product>
     <Copyright>EnduraByte LLC 2025</Copyright>
     <!-- Reduces flagging as malware -->


### PR DESCRIPTION
Fixes https://github.com/nref/BrowseRouter/issues/89

The argument in the open command needs to be quoted in order to handle URLs with spaces.