### PR TITLE
chore: Upgrade to .NET 10 and enable Native AOT support

### DIFF
--- a/BrowseRouter/BrowseRouter.csproj
+++ b/BrowseRouter/BrowseRouter.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ApplicationIcon>logo.ico</ApplicationIcon>
-	  <PublishTrimmed>true</PublishTrimmed>
+    <PublishAot>true</PublishAot>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 

--- a/BrowseRouter/Infrastructure/App.cs
+++ b/BrowseRouter/Infrastructure/App.cs
@@ -13,8 +13,7 @@ public static class App
         return _exePath;
       }
 
-      string dir = AppDomain.CurrentDomain.BaseDirectory;
-      _exePath = Path.Combine(dir, AppDomain.CurrentDomain.FriendlyName + ".exe");
+      _exePath = Environment.ProcessPath ?? string.Empty;
       return _exePath;
     }
   }

--- a/BrowseRouter/Interop/Win32/BasicProcessInfo.cs
+++ b/BrowseRouter/Interop/Win32/BasicProcessInfo.cs
@@ -8,7 +8,7 @@ namespace BrowseRouter.Interop.Win32
   /// A utility class to determine a process parent. Originally copied from https://stackoverflow.com/a/3346055
   /// </summary>
   [StructLayout(LayoutKind.Sequential)]
-  public struct BasicProcessInfo
+  public partial struct BasicProcessInfo
   {
     // These members must match PROCESS_BASIC_INFORMATION
     internal IntPtr Reserved1;
@@ -18,8 +18,8 @@ namespace BrowseRouter.Interop.Win32
     internal IntPtr UniqueProcessId;
     internal IntPtr InheritedFromUniqueProcessId;
 
-    [DllImport("ntdll.dll")]
-    private static extern int NtQueryInformationProcess(IntPtr processHandle, int processInformationClass, ref BasicProcessInfo processInformation, int processInformationLength, out int returnLength);
+    [LibraryImport("ntdll.dll")]
+    private static partial int NtQueryInformationProcess(IntPtr processHandle, int processInformationClass, ref BasicProcessInfo processInformation, int processInformationLength, out int returnLength);
 
 
     /// <summary>

--- a/BrowseRouter/Interop/Win32/Comctl32.cs
+++ b/BrowseRouter/Interop/Win32/Comctl32.cs
@@ -2,11 +2,11 @@
 
 namespace BrowseRouter.Interop.Win32;
 
-internal static class Comctl32
+internal static partial class Comctl32
 {
   /// <summary>
   /// Requires an app manifest file on .NET Core
   /// </summary>
-  [DllImport("Comctl32.dll", CharSet = CharSet.Unicode)]
-  public static extern nint LoadIconWithScaleDown(nint hinst, string pszName, int cx, int cy, out nint phico);
+  [LibraryImport("Comctl32.dll", StringMarshalling = StringMarshalling.Utf16)]
+  public static partial nint LoadIconWithScaleDown(nint hinst, string pszName, int cx, int cy, out nint phico);
 }

--- a/BrowseRouter/Interop/Win32/Kernel32.cs
+++ b/BrowseRouter/Interop/Win32/Kernel32.cs
@@ -2,15 +2,16 @@
 
 namespace BrowseRouter.Interop.Win32;
 
-public static class Kernel32
+public static partial class Kernel32
 {
-  [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
-  public static extern nint GetModuleHandle(string? lpModuleName);
+  [LibraryImport("kernel32.dll", EntryPoint = "GetModuleHandleW", StringMarshalling = StringMarshalling.Utf16)]
+  public static partial nint GetModuleHandle(string? lpModuleName);
 
   private const uint ATTACH_PARENT_PROCESS = 0x0ffffffff;
 
-  [DllImport("kernel32.dll")]
-  private static extern bool AttachConsole(uint dwProcessId);
+  [LibraryImport("kernel32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  private static partial bool AttachConsole(uint dwProcessId);
 
   public static void AttachToParentConsole() => AttachConsole(ATTACH_PARENT_PROCESS);
 }

--- a/BrowseRouter/Interop/Win32/User32.cs
+++ b/BrowseRouter/Interop/Win32/User32.cs
@@ -6,32 +6,34 @@ namespace BrowseRouter.Interop.Win32;
 public static partial class User32
 {
   // DllImports used to get window title for source program.
-  [DllImport("user32.dll")]
-  public static extern nint GetForegroundWindow();
+  [LibraryImport("user32.dll")]
+  public static partial nint GetForegroundWindow();
 
-  [DllImport("user32.dll")]
-  public static extern int GetWindowText(nint hWnd, StringBuilder text, int count);
+  [LibraryImport("user32.dll", EntryPoint = "GetWindowTextW", StringMarshalling = StringMarshalling.Utf16)]
+  public static partial int GetWindowText(nint hWnd, [Out] char[] lpString, int nMaxCount);
 
   public static string GetActiveWindowTitle()
   {
     string result = "";
     const int nChars = 256;
-    StringBuilder buff = new(nChars);
+    char[] buff = new char[nChars];
     nint handle = GetForegroundWindow();
 
-    if (GetWindowText(handle, buff, nChars) > 0)
+    int length = GetWindowText(handle, buff, nChars);
+    if (length > 0)
     {
-      result = buff.ToString();
+      result = new string(buff, 0, length);
     }
     return result;
   }
 
-  [DllImport("user32.dll")]
-  public static extern nint CreateWindowEx(uint dwExStyle, 
+  [LibraryImport("user32.dll", EntryPoint = "CreateWindowExW", StringMarshalling = StringMarshalling.Utf16)]
+  public static partial nint CreateWindowEx(uint dwExStyle, 
     string lpClassName, 
     string lpWindowName, 
     uint dwStyle, int x, int y, int nWidth, int nHeight, nint hWndParent, nint hMenu, nint hInstance, nint lpParam);
 
-  [DllImport("user32.dll")]
-  public static extern bool DestroyWindow(nint hWnd);
+  [LibraryImport("user32.dll")]
+  [return: MarshalAs(UnmanagedType.Bool)]
+  public static partial bool DestroyWindow(nint hWnd);
 }

--- a/BrowseRouter/Services/NotifyService.cs
+++ b/BrowseRouter/Services/NotifyService.cs
@@ -22,7 +22,7 @@ public class NotifyService : INotifyService
     | Shell32.NIF_STATE; // Enables hiding system tray icon
 
   private static nint _hIcon;
-  private static nint _hInstance = Kernel32.GetModuleHandle(App.ExePath);
+  private static nint _hInstance = Kernel32.GetModuleHandle(null);
   private readonly bool _noSound;
 
   public NotifyService(bool noSound = false) 
@@ -79,7 +79,7 @@ public class NotifyService : INotifyService
 
   private static NotifyIconData GetNid(nint hWnd, string title, string message, bool noSound) => new NotifyIconData
   {
-    cbSize = Marshal.SizeOf(typeof(NotifyIconData)),
+    cbSize = Marshal.SizeOf<NotifyIconData>(),
     hWnd = hWnd,
     uID = 1,
     uFlags = _flags,

--- a/Tests/BrowseRouter.Tests/BrowseRouter.Tests.csproj
+++ b/Tests/BrowseRouter.Tests/BrowseRouter.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Description
This pull request upgrades the project framework to .NET 10 and transitions the application to use Native AOT (Ahead-Of-Time) compilation, replacing the previous trimming approach. To ensure full compatibility with the Native AOT deployment model, several reflection-reliant and legacy APIs have been refactored. 

## Key Changes
* **Framework & Build Updates**: 
  * Upgraded `TargetFramework` from `net8.0-windows` to `net10.0-windows`.
  * Replaced `<PublishTrimmed>` with `<PublishAot>` and enabled `<AllowUnsafeBlocks>` in the project file.
* **Source-Generated P/Invoke (AOT Compatibility)**: 
  * Migrated legacy `[DllImport]` attributes to `[LibraryImport]` in Win32 interop classes (`BasicProcessInfo`, `Comctl32`, `Kernel32`).
  * Converted affected interop classes, structs, and methods to `partial` to leverage compile-time interop source generation.
  * Updated string marshaling explicitly to `Utf16`.
* **AOT-Safe Path Resolution**: 
  * Refactored executable path resolution in `Infrastructure/App.cs`, replacing `AppDomain.CurrentDomain` with `Environment.ProcessPath` to ensure reliable behavior in AOT environments.